### PR TITLE
Remove CI tasks on push to master

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,8 +1,6 @@
 name: .NET Core
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
CI tasks occurred on both pull request to master and after once that pull request is merged to, duplicating the work.

This prevents that.

The downside is that CI tasks do not occur for direct pushes to master, which should not occur anyways.