### PR TITLE
Revert "Remove CI tasks on push to master"

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,6 +1,8 @@
 name: .NET Core
 
 on:
+  push:
+    branches: [ master ]
   pull_request:
     branches: [ master ]
 


### PR DESCRIPTION
Reverts EvanQuan/Chubberino#106

CI check mark does not appear on master.